### PR TITLE
Update Ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ or [build them from sources](#building-from-sources).
    Examples:  
    <details><summary><i>Ubuntu</i></summary>
    <code>
-   sudo apt-get install gcc-7 g++-7 cmake libjpeg-dev libpng-dev libtiff5 libtiff5-dev libboost-test1.67-dev libboost-test1.67.0 qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev
+   sudo apt-get install build-essential cmake libjpeg-dev libpng-dev libtiff5 libtiff5-dev libboost-test1.67-dev libboost-test1.67.0 qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev
    </code>
    </details>
    <details><summary><i>OpenSUSE</i></summary>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Building ScanTailor Advanced and its dependencies
 
 ScanTailor Advanced: https://github.com/4lex4/scantailor-advanced
 
-This is an instruction for building ScanTailor Advanced and its dependencies for **Windows** and **Linux**. 
+This is an instruction for building ScanTailor Advanced and its dependencies for **Windows** and **Linux**.
 
 #### <u>Contents</u>:
 * [Dependencies](#dependencies)
@@ -53,8 +53,8 @@ Usage: `cmake -D <option>=<value> ...`
 
 Useful options:  
 * `CMAKE_INSTALL_PREFIX=<path>` - install ScanTailor Advanced into the `path` after building.  
-* `PORTABLE_VERSION=[ON|OFF]` - whether to build portable version. If enabled, ScanTailor tries to store its settings 
-    and files inside the application folder if possible, else ScanTailor stores those in the system specific paths. 
+* `PORTABLE_VERSION=[ON|OFF]` - whether to build portable version. If enabled, ScanTailor tries to store its settings
+    and files inside the application folder if possible, else ScanTailor stores those in the system specific paths.
     If disabled, the settings and files are always stored in the system specific paths.  
 
 Instructions
@@ -99,14 +99,14 @@ Supported toolchains for Windows are MinGW and MSVC.
 #### <a name="windows-mingw-preparing-tools"></a> Preparing tools
 1. Install mingw64 into the path `C:\mingw64` / `C:\mingw32`
 2. Install msys2 into the path `C:\msys64` / `C:\msys32`
-3. Run script `configure_msys.bat` with administrative permissions 
+3. Run script `configure_msys.bat` with administrative permissions
 4. Add mingw into the `PATH` environment variable:  
    1. Go to: My Computer -> Right click -> Properties -> Advanced system settings  
    2. Click Environment variables  
    3. Find `Path` variable in the system variables tab and paste
       `;C:\mingw64\bin` / `;C:\mingw32\bin` at the end of its value
 
-#### <a name="windows-mingw-building-dependencies"></a> Building dependencies 
+#### <a name="windows-mingw-building-dependencies"></a> Building dependencies
 1. Run script `configure_libs_x32.bat` / `configure_libs_x64.bat`
 2. Open the command prompt (`cmd`), navigate to the `scantailor-libs-build-master`
    directory (`cd /d "<dir>"`) and enter:
@@ -167,7 +167,7 @@ Supported toolchains for Windows are MinGW and MSVC.
 
 #### <a name="windows-msvc-building-for-windows-xp"></a> *<u>Building for Windows XP</u>*
 #### <a name="windows-msvc-winxp-building-dependencies"></a> Building dependencies
-1. <a name="configure-environment-msvc-winxp"></a> 
+1. <a name="configure-environment-msvc-winxp"></a>
    Configure some environment variables. Open the Native Tools Command Prompt for VS and enter:
 
    ~~~~
@@ -198,7 +198,7 @@ Supported toolchains for Windows are MinGW and MSVC.
 
 ### Linux
 #### <a name="linux-getting-dependencies"></a> Getting dependencies
-Linux users have two options here: [download them from their repositories](#downloading-from-repositories) 
+Linux users have two options here: [download them from their repositories](#downloading-from-repositories)
 or [build them from sources](#building-from-sources).
 
 #### <a name="linux-downloading-from-repositories"></a> *Downloading from repositories*
@@ -208,7 +208,7 @@ or [build them from sources](#building-from-sources).
    Examples:  
    <details><summary><i>Ubuntu</i></summary>
    <code>
-   sudo apt-get install gcc-7 g++-7 cmake libjpeg-dev libpng-dev libtiff5 libtiff5-dev libboost-test1.63-dev libboost-test1.63.0 qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev
+   sudo apt-get install gcc-7 g++-7 cmake libjpeg-dev libpng-dev libtiff5 libtiff5-dev libboost-test1.67-dev libboost-test1.67.0 qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev
    </code>
    </details>
    <details><summary><i>OpenSUSE</i></summary>
@@ -259,7 +259,7 @@ or [build them from sources](#building-from-sources).
    sudo make install
    ~~~~
 
-   After building and installing copy [findqt.sh and findqt.csh](https://files.inbox.eu/ticket/5bf43247570a1c111ed0eaa8d6a770ff87ec1b62/findqt.tar.xz) 
+   After building and installing copy [findqt.sh and findqt.csh](https://files.inbox.eu/ticket/5bf43247570a1c111ed0eaa8d6a770ff87ec1b62/findqt.tar.xz)
    into `/etc/profile.d/` folder then enter `sudo . ~/.profile && . /etc/profile` in console to apply the changes made instantly
    or [add Qt into PATH](http://doc.qt.io/qt-5/linux-building.html) yourself.
 
@@ -303,6 +303,6 @@ Packaging
    Examples:
      1. To create a Linux DEB package use: `cpack -G "DEB"`  
      2. To create a Linux RPM package use: `cpack -G "RPM"`   
-          *Note:* `rpm-build` package has to be installed. 
+          *Note:* `rpm-build` package has to be installed.
      3. To create an installer for Windows use: `cpack -G "NSIS"`   
           *Note:* [NSIS](https://sourceforge.net/projects/nsis/files/) has to be installed.


### PR DESCRIPTION
I used the following dependencies to install ScanTailor Advanced in Docker containers running both Ubuntu 18.04 and 20.04

Line 211 is the pertinent line (everything else is my text editor stripping trailing spaces)